### PR TITLE
Adding python-markdown extensions and bleach to sanitize html

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ bower_components/
 # Coverage
 htmlcov/
 .coverage
+
+# Pycharm
+.idea/

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setup(
     install_requires=[
         'wagtail>=1.8',
         'markdown>=2.5',
+        'bleach>=2.0.0'
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',

--- a/wagtailmarkdownblock/blocks.py
+++ b/wagtailmarkdownblock/blocks.py
@@ -1,6 +1,7 @@
 from django.forms import Media
 from django.utils.safestring import mark_safe
 
+import bleach
 from markdown import markdown
 from wagtail.wagtailcore.blocks import StructBlock, TextBlock
 
@@ -28,14 +29,44 @@ class MarkdownBlock(StructBlock):
         )
 
     def render(self, value, context=None):
-        md = markdown(
+        formatted_html = markdown(
             value['markdown'],
-            [
-                'markdown.extensions.fenced_code',
-                'codehilite',
+            extensions=[
+                'markdown.extensions.extra',
+                'markdown.extensions.codehilite',
+                'markdown.extensions.nl2br',
+                'markdown.extensions.sane_lists',
+                'markdown.extensions.toc',
+                'markdown.extensions.wikilinks'
             ],
+            output_format='html5'
         )
-        return mark_safe(md)
+
+        # Sanitizing html with bleach to avoid code injection
+        sanitized_html = bleach.clean(
+            formatted_html,
+            # Allowed tags, attributes and styles
+            tags=[
+                'p', 'div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'tt', 'pre', 'em', 'strong', 'ul', 'li',
+                'dl', 'dd', 'dt', 'code', 'img', 'a', 'table', 'tr', 'th', 'td', 'tbody', 'caption', 'colgroup',
+                'thead', 'tfoot', 'blockquote', 'ol', 'hr', 'br'
+            ],
+            attributes={
+                '*': ['class', 'style', 'id'],
+                'a': ['href', 'target', 'rel'],
+                'img': ['src', 'alt'],
+                'tr': ['rowspan', 'colspan'],
+                'td': ['rowspan', 'colspan', 'align']
+            },
+            styles=[
+                'color', 'background-color', 'font-family', 'font-weight', 'font-size', 'width', 'height',
+                'text-align', 'border', 'border-top', 'border-bottom', 'border-left', 'border-right', 'padding',
+                'padding-top', 'padding-bottom', 'padding-left', 'padding-right', 'margin', 'margin-top',
+                'margin-bottom', 'margin-left', 'margin-right'
+            ]
+        )
+
+        return mark_safe(sanitized_html)
 
     class Meta:
         icon = 'code'


### PR DESCRIPTION
I have added some markdown extensions, please take a look here (https://pythonhosted.org/Markdown/extensions/index.html) and tell me if we can add some more or remove.

Also i have added Bleach to sanitize the HTML formatted by markdown and add a 'security layer' to the markdown formatter.

Here is the documentation: https://bleach.readthedocs.io/en/latest/