### PR TITLE
add sup and sub to allowed elements

### DIFF
--- a/wagtailmarkdownblock/utils.py
+++ b/wagtailmarkdownblock/utils.py
@@ -26,7 +26,7 @@ def render(text):
         tags=[
             'p', 'div', 'span', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6', 'tt', 'pre', 'em', 'strong', 'ul', 'li',
             'dl', 'dd', 'dt', 'code', 'img', 'a', 'table', 'tr', 'th', 'td', 'tbody', 'caption', 'colgroup',
-            'thead', 'tfoot', 'blockquote', 'ol', 'hr', 'br'
+            'thead', 'tfoot', 'blockquote', 'ol', 'hr', 'br', "sub", "sup"
         ],
         attributes={
             '*': ['class', 'style', 'id'],


### PR DESCRIPTION
Hi Timothy, Milton,

thanks for the markdownblock, it comes quite handy for a current project.

Alas, I tried to use footnotes and discovered that sup was cleaned from the markdown output, i.e. the sup markup showed as content...

So I added sup (and sub, for symmetry ;) to the allowed tags, since one of my future users cannot live without footnotes...

It would be great if you accept this so I don't need local changes.

Cheers, Mathias